### PR TITLE
Add event bus and 3D object manager

### DIFF
--- a/IdeWebGlGameEngine/src/core/EventBus.js
+++ b/IdeWebGlGameEngine/src/core/EventBus.js
@@ -1,2 +1,45 @@
 // src/core/EventBus.js
-// Système d'événements entre modules
+// Minimal event bus for communication between modules
+
+export class EventBus {
+  constructor() {
+    this._listeners = new Map();
+  }
+
+  /**
+   * Register a listener for an event.
+   * @param {string} evt
+   * @param {(payload:any)=>void} fn
+   * @returns {() => void} unsubscribe function
+   */
+  on(evt, fn) {
+    if (!this._listeners.has(evt)) this._listeners.set(evt, new Set());
+    const set = this._listeners.get(evt);
+    set.add(fn);
+    return () => this.off(evt, fn);
+  }
+
+  /** Remove listener or all listeners for event */
+  off(evt, fn) {
+    const set = this._listeners.get(evt);
+    if (!set) return;
+    if (fn) set.delete(fn); else set.clear();
+    if (!set.size) this._listeners.delete(evt);
+  }
+
+  /** Emit event with optional payload */
+  emit(evt, payload) {
+    const set = this._listeners.get(evt);
+    if (!set) return;
+    for (const fn of [...set]) {
+      try {
+        fn(payload);
+      } catch (err) {
+        console.error('[EventBus]', err);
+      }
+    }
+  }
+}
+
+export default EventBus;
+

--- a/IdeWebGlGameEngine/src/core/Object3DManager.js
+++ b/IdeWebGlGameEngine/src/core/Object3DManager.js
@@ -1,2 +1,37 @@
 // src/core/Object3DManager.js
-// Gestion des objets 3D dans la scène
+// Gestion simple des objets 3D et diffusion d'événements
+
+import bus from '../js/core/bus.js';
+
+class Object3DManager {
+  constructor(){
+    this.objects = new Map();
+    this._nextId = 1;
+  }
+
+  /** Ajoute un objet et notifie les modules */
+  add(object){
+    const id = object.id || `obj-${this._nextId++}`;
+    object.id = id;
+    this.objects.set(id, object);
+    bus.emit('object3d:add', object);
+    return id;
+  }
+
+  /** Supprime un objet et notifie */
+  remove(id){
+    const obj = this.objects.get(id);
+    if (!obj) return;
+    this.objects.delete(id);
+    bus.emit('object3d:remove', obj);
+  }
+
+  /** Retourne un objet par son id */
+  get(id){ return this.objects.get(id) || null; }
+
+  /** Liste tous les objets */
+  list(){ return Array.from(this.objects.values()); }
+}
+
+export const object3DManager = new Object3DManager();
+export default object3DManager;

--- a/IdeWebGlGameEngine/src/js/core/bus.js
+++ b/IdeWebGlGameEngine/src/js/core/bus.js
@@ -1,0 +1,8 @@
+// src/js/core/bus.js
+// Shared instance of EventBus for modules
+
+import { EventBus } from '../../core/EventBus.js';
+
+export const bus = new EventBus();
+export default bus;
+

--- a/IdeWebGlGameEngine/src/js/modules/viewport3d/engine.js
+++ b/IdeWebGlGameEngine/src/js/modules/viewport3d/engine.js
@@ -1,12 +1,23 @@
 import { initRenderer, drawScene } from './renderer.js';
 import { attachInput } from './input.js';
 import { addCube, addPlane } from './primitives.js';
+import bus from '../../core/bus.js';
+import object3DManager from '../../../core/Object3DManager.js';
 
 const state = {
   gl: null, canvas: null,
   camera: { mode:'persp', pos:[3,3,3], target:[0,0,0], up:[0,1,0], fov:60, orthoSize:5 },
   scene: { objects: [] },
 };
+
+bus.on('object3d:add', (obj) => {
+  if (!state.scene.objects.includes(obj)) state.scene.objects.push(obj);
+});
+
+bus.on('object3d:remove', (obj) => {
+  const idx = state.scene.objects.indexOf(obj);
+  if (idx !== -1) state.scene.objects.splice(idx, 1);
+});
 
 export function initViewport3D(canvas){
   state.canvas = canvas;
@@ -15,8 +26,10 @@ export function initViewport3D(canvas){
   state.gl = gl;
   initRenderer(gl, state);
   attachInput(canvas, state);
-  addPlane(state.scene, { size:10, color:[0.2,0.2,0.25], grid:true });
-  addCube(state.scene, { size:1, color:[0.8,0.3,0.3] });
+  const plane = addPlane(state.scene, { size:10, color:[0.2,0.2,0.25], grid:true });
+  const cube = addCube(state.scene, { size:1, color:[0.8,0.3,0.3] });
+  object3DManager.add(plane);
+  object3DManager.add(cube);
   requestAnimationFrame(loop);
 }
 function loop(){ drawScene(state.gl, state); requestAnimationFrame(loop); }

--- a/IdeWebGlGameEngine/src/js/modules/viewport3d/primitives.js
+++ b/IdeWebGlGameEngine/src/js/modules/viewport3d/primitives.js
@@ -8,20 +8,24 @@ export function addCube(scene, { size=1, color=[0.8,0.8,0.8] }={}){
     -s, s,-s,  s, s,-s,  s, s, s,  -s, s,-s,  s, s, s,  -s, s, s,
     -s,-s,-s,  s,-s,-s,  s,-s, s,  -s,-s,-s,  s,-s, s,  -s,-s, s
   ];
-  scene.objects.push({ vertices:v, color });
-  return scene.objects[scene.objects.length-1];
+  const obj = { vertices:v, color };
+  scene.objects.push(obj);
+  return obj;
 }
 export function addPlane(scene, { size=10, color=[0.2,0.2,0.25], grid=false }={}){
+  let obj;
   if (!grid){
     const s=size/2;
     const v=[-s,0,-s, s,0,-s, s,0,s, -s,0,-s, s,0,s, -s,0,s];
-    scene.objects.push({ vertices:v, color });
-    return;
+    obj = { vertices:v, color };
+  } else {
+    const step=1, half=size/2;
+    const verts=[];
+    for(let i=-half;i<=half;i+=step){
+      verts.push(-half,0,i, half,0,i,  i,0,-half, i,0,half);
+    }
+    obj = { vertices:verts, color, mode:WebGLRenderingContext.LINES };
   }
-  const step=1, half=size/2;
-  const verts=[];
-  for(let i=-half;i<=half;i+=step){
-    verts.push(-half,0,i, half,0,i,  i,0,-half, i,0,half);
-  }
-  scene.objects.push({ vertices:verts, color, mode:WebGLRenderingContext.LINES });
+  scene.objects.push(obj);
+  return obj;
 }


### PR DESCRIPTION
## Summary
- implement reusable EventBus and expose global instance
- manage 3D objects with Object3DManager emitting add/remove events
- wire viewport engine to the event bus and make primitives return created objects

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689f42d17260832e82674043822e5243