### PR TITLE
fix: enable drag and drop from node library to visual scripting viewport

### DIFF
--- a/IdeWebGlGameEngine/src/js/app.js
+++ b/IdeWebGlGameEngine/src/js/app.js
@@ -4,6 +4,7 @@
 
 // BLOCK 1 — IMPORTS
 import { renderLibrary } from './modules/visual/Library.js';
+import { registerCatalog } from './modules/visual/catalog.js';
 import Inspector from './modules/inspector/inspector.js';
 import View3D from './modules/viewport3d/engine.js';              // optional; ok if the canvas is absent
 import { mountOutliner } from './modules/outliner/outliner.js';    // optional; ok if file exists
@@ -160,6 +161,7 @@ function initTabs() {
 // BLOCK 10 — initUI + DOM ready
 async function initUI() {
   await ensureGraph();
+  registerCatalog();
   await initLibrary();
   initInspectorUI('visual');
   initOutlinerUI();

--- a/IdeWebGlGameEngine/src/js/modules/visual/Library.js
+++ b/IdeWebGlGameEngine/src/js/modules/visual/Library.js
@@ -49,14 +49,11 @@ function renderResults(container, grouped, query, onCreate){
              // click = créer
              btn.onclick=()=> onCreate && onCreate(spec.type);
 
-             // drag = DnD vers node-area
-             btn.draggable = true;
-             btn.dataset.nodeType = spec.type;
-             btn.addEventListener('dragstart', (e)=>{
-               e.dataTransfer.setData('text/node-type', spec.type);
-               e.dataTransfer.setData('text/plain', spec.type); // fallback
-               e.dataTransfer.effectAllowed='copy';
-             });
+            // drag = DnD vers node-area
+            btn.draggable = true;
+            btn.ondragstart = (e) => {
+               e.dataTransfer.setData("application/x-node-type", JSON.stringify(spec));
+            };
 
              grid.appendChild(btn);
            });

--- a/IdeWebGlGameEngine/src/js/modules/visual/graph.js
+++ b/IdeWebGlGameEngine/src/js/modules/visual/graph.js
@@ -523,8 +523,20 @@ export function createGraph({area, viewport, wireSvg, libContainer, zoomLabel, n
     }
   }
   area.addEventListener('dragover',(e)=>e.preventDefault());
-  area.addEventListener('drop',(e)=>{ e.preventDefault(); const data=e.dataTransfer.getData('application/x-node-type'); if(!data) return;
-    const def=JSON.parse(data); const c=screenToContent(e.clientX,e.clientY); const id=addNode(def,c.x,c.y); log(`Dropped node: ${def.type} (#${id})`); drawWires(); });
+  area.addEventListener('drop',(e)=>{
+    e.preventDefault();
+    const data=e.dataTransfer.getData('application/x-node-type');
+    if(!data) return;
+    const def=JSON.parse(data);
+    if (!def || !def.type) {
+      console.warn('❌ Node drop ignored — invalid spec:', data);
+      return;
+    }
+    const c=screenToContent(e.clientX,e.clientY);
+    const id=addNode(def,c.x,c.y);
+    log(`Dropped node: ${def.type} (#${id})`);
+    drawWires();
+  });
 
   /* ---------- JSON / assign / (dé)serialisation ---------- */
   function serializeNodes(){ const arr=[]; for(const n of VS.nodes.values()){ arr.push({id:n.id,type:n.def.type,title:n.def.title,x:parseFloat(n.el.style.left||'0'),y:parseFloat(n.el.style.top||'0')}); } return arr; }


### PR DESCRIPTION
## Summary
- fix node library drag and drop to send full node spec
- register node catalog and handle invalid specs on drop

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a032994d34832eaad1353a0583e373