### PR TITLE
feat: expand outliner and inspector

### DIFF
--- a/IdeWebGlGameEngine/src/components/Inspector.vue
+++ b/IdeWebGlGameEngine/src/components/Inspector.vue
@@ -1,2 +1,47 @@
-<!-- src/components/Inspector.vue -->
-<!-- Composant d'inspection contextuelle -->
+<template>
+  <div>
+    <ViewportInspector v-if="context==='viewport'" />
+  </div>
+</template>
+
+<script>
+// Bloc 1 imports
+import { ref } from 'vue';
+import TransformInspector from './inspector/TransformInspector.vue';
+import PhysicsPanel from './inspector/PhysicsPanel.vue';
+import AnimationPanel from './inspector/AnimationPanel.vue';
+import bus from '../js/core/bus.js';
+import GameProps from '../js/services/gameprops.service.js';
+import { OutlinerService } from '../js/services/outliner.service.js';
+
+// Bloc 2 state / types / constantes
+const context = ref('viewport');
+const selection = ref([]);
+
+// Bloc 3 opérateurs
+bus.on('selection:change', sel=> selection.value = sel);
+function persist(){
+  const id = selection.value[0];
+  if(!id) return;
+  const obj = OutlinerService.snapshot().objects[id];
+  const extras = { ...(obj.extras||{}), gameProps: GameProps.list(id) };
+  OutlinerService.setExtras(id, extras);
+}
+const GamePropsPanel = {
+  name:'GamePropsPanel',
+  setup(){
+    function list(){ return GameProps.list(selection.value[0]); }
+    function add(){ const n=prompt('Name'); if(!n) return; GameProps.set(selection.value[0], n, 'Float', 0.0); persist(); bus.emit('gameprops:set'); }
+    function rename(p){ const n=prompt('Rename',p.name); if(!n) return; GameProps.rename(selection.value[0], p.name, n); persist(); bus.emit('gameprops:rename'); }
+    function remove(p){ GameProps.remove(selection.value[0], p.name); persist(); bus.emit('gameprops:remove'); }
+    function move(p,d){ const arr=list(); const i=arr.findIndex(x=>x.name===p.name); const j=i+d; if(j<0||j>=arr.length) return; arr.splice(i,1); arr.splice(j,0,p); arr.forEach(pr=>GameProps.remove(selection.value[0], pr.name)); arr.forEach(pr=>GameProps.set(selection.value[0], pr.name, pr.type, pr.value)); persist(); bus.emit('gameprops:reorder'); }
+    function info(p){ console.log('GameProp', p); }
+    return { list, add, rename, remove, move, info };
+  },
+  template:`<div v-if="list().length || true"><h3>Game Properties</h3><div v-for="p in list()" :key="p.name"><span>{{p.name}} ({{p.type}})</span><button @click="() => rename(p)">Rename</button><button @click="() => remove(p)">Delete</button><button @click="() => move(p,-1)">↑</button><button @click="() => move(p,1)">↓</button><button @click="() => info(p)">(i)</button></div><button @click="add">Add</button></div>`
+};
+const ViewportInspector = { components:{ TransformInspector, GamePropsPanel, PhysicsPanel, AnimationPanel }, template:`<div><TransformInspector/><GamePropsPanel/><PhysicsPanel/><AnimationPanel/></div>` };
+
+// Bloc 4 exports
+export default { name:'Inspector', components:{ ViewportInspector }, setup(){ return { context }; } };
+</script>

--- a/IdeWebGlGameEngine/src/components/Outliner.vue
+++ b/IdeWebGlGameEngine/src/components/Outliner.vue
@@ -1,2 +1,66 @@
-<!-- src/components/Outliner.vue -->
-<!-- Gestion hiérarchique des objets -->
+<template>
+  <div class="outliner">
+    <ul>
+      <TreeCollection :id="tree.rootId" />
+    </ul>
+  </div>
+</template>
+
+<script>
+// Bloc 1 imports
+import { reactive, computed } from 'vue';
+import { OutlinerService } from '../js/services/outliner.service.js';
+import bus from '../js/core/bus.js';
+
+// Bloc 2 state / types / constantes
+const icons = { MESH:'🧊', ARMATURE:'🦴', CAMERA:'📷', LIGHT:'💡', EMPTY:'◻️', COLLECTION:'🗂️' };
+const tree = reactive(OutlinerService.snapshot());
+const selection = reactive({ ids: OutlinerService.getSelection() });
+
+// Bloc 3 opérateurs
+function refresh(){ Object.assign(tree, OutlinerService.snapshot()); }
+OutlinerService.on(evt=>{ if(evt==='selection'){ selection.ids = OutlinerService.getSelection(); bus.emit('selection:change', selection.ids); } else refresh(); });
+function isSel(id){ return selection.ids.includes(id); }
+function select(id,e){ if(e.ctrlKey||e.metaKey) OutlinerService.toggleSelect(id); else OutlinerService.selectOnly(id); }
+function toggleVis(o){ OutlinerService.toggleVisible(o.id); refresh(); }
+function toggleLock(o){ OutlinerService.toggleLocked(o.id); refresh(); }
+function rename(item,isCol){ const n=prompt('Rename', item.name); if(n) isCol?OutlinerService.renameCollection(item.id,n):OutlinerService.renameObject(item.id,n); }
+function remove(item,isCol){ if(!confirm('Delete?')) return; isCol?OutlinerService.removeCollection(item.id):OutlinerService.removeObject(item.id); }
+function context(item,isCol,e){ e.preventDefault(); const a=prompt('Action? rename|delete|move'); if(a==='rename') rename(item,isCol); else if(a==='delete') remove(item,isCol); else if(a==='move' && !isCol){ const t=prompt('Collection id'); if(t) OutlinerService.moveToCollection(item.id,t); } }
+function dragStart(item,isCol,e){ if(isCol) return; e.dataTransfer.setData('text/plain', item.id); }
+function dropObj(target,e){ const id=e.dataTransfer.getData('text/plain'); if(id) OutlinerService.reparent(id,target.id); }
+function dropCol(target,e){ const id=e.dataTransfer.getData('text/plain'); if(id) OutlinerService.moveToCollection(id,target.id); }
+function allow(e){ e.preventDefault(); }
+const NodeObject = {
+  name:'NodeObject',
+  props:['id'],
+  setup(p){ const obj = computed(()=> tree.objects[p.id]); return { obj, icons, isSel, select, toggleVis, toggleLock, dragStart, allow, dropObj, context }; },
+  template:`
+    <li :class="{selected:isSel(obj.id)}" draggable="true" @dragstart="dragStart(obj,false,$event)" @dragover="allow" @drop="dropObj(obj,$event)" @contextmenu="context(obj,false,$event)">
+      <span @click.stop="toggleVis(obj)">{{ obj.visible ? '👁️' : '🙈' }}</span>
+      <span @click.stop="toggleLock(obj)">{{ obj.locked ? '🔒' : '🔓' }}</span>
+      <span @click="select(obj.id,$event)">{{ icons[obj.type] }} {{ obj.name }}</span>
+      <ul v-if="obj.children && obj.children.length">
+        <NodeObject v-for="cid in obj.children" :key="cid" :id="cid" />
+      </ul>
+    </li>`
+};
+const NodeCollection = {
+  name:'NodeCollection',
+  props:['id'],
+  components:{ NodeObject },
+  setup(p){ const col = computed(()=> tree.collections[p.id]); return { col, icons, select, allow, dropCol, context }; },
+  template:`
+    <li @contextmenu="context(col,true,$event)" @dragover="allow" @drop="dropCol(col,$event)">
+      <div @click="select(col.id,$event)">{{ icons.COLLECTION }} {{ col.name }}</div>
+      <ul>
+        <NodeCollection v-for="cid in col.children" :key="cid" :id="cid" />
+        <NodeObject v-for="oid in col.objects" :key="oid" :id="oid" />
+      </ul>
+    </li>`
+};
+NodeCollection.components.NodeCollection = NodeCollection;
+
+// Bloc 4 exports
+export default { name:'Outliner', components:{ TreeCollection:NodeCollection, TreeObject:NodeObject } };
+</script>

--- a/IdeWebGlGameEngine/src/components/inspector/AnimationPanel.vue
+++ b/IdeWebGlGameEngine/src/components/inspector/AnimationPanel.vue
@@ -1,0 +1,69 @@
+<template>
+  <div v-if="id">
+    <h3>Animation</h3>
+    <div>
+      <label>Clip</label>
+      <select v-model="clip">
+        <option v-for="c in clips" :key="c.name">{{c.name}}</option>
+      </select>
+      <label>Skeleton</label>
+      <select v-model="skeleton">
+        <option v-for="a in armatures" :key="a.id" :value="a.id">{{a.name}}</option>
+      </select>
+      <input type="number" step="0.001" v-model.number="blend" />
+      <button @click="play">Play</button>
+    </div>
+    <div>
+      <label>State Machine</label>
+      <textarea v-model="sm" @change="saveSM"></textarea>
+    </div>
+  </div>
+  <div v-else>Animation: no selection</div>
+</template>
+
+<script>
+// Bloc 1 imports
+import { ref, computed } from 'vue';
+import bus from '../../js/core/bus.js';
+import { OutlinerService } from '../../js/services/outliner.service.js';
+import AnimationService from '../../js/services/animation.service.js';
+
+// Bloc 2 state / types / constantes
+const id = ref(null);
+const clip = ref('');
+const skeleton = ref('');
+const blend = ref(0.2);
+const clips = ref([]);
+const sm = ref('');
+const armatures = computed(()=>{
+  const sn = OutlinerService.snapshot();
+  return Object.values(sn.objects).filter(o=>o.type==='ARMATURE');
+});
+
+// Bloc 3 opérateurs
+function load(target){
+  id.value = target;
+  if(!target) return;
+  const obj = OutlinerService.snapshot().objects[target];
+  clip.value = obj?.extras?.animationBindings?.clips?.[0] || '';
+  skeleton.value = obj?.extras?.animationBindings?.skeletonNodeId || '';
+  sm.value = JSON.stringify(obj?.extras?.stateMachine||{}, null, 2);
+}
+function play(){
+  if(!skeleton.value || !clip.value) return;
+  AnimationService.play(skeleton.value, clip.value, blend.value);
+}
+function saveSM(){
+  if(!id.value) return;
+  let parsed={};
+  try{ parsed = JSON.parse(sm.value); }catch(e){ return; }
+  const obj = OutlinerService.snapshot().objects[id.value];
+  const extras = { ...(obj.extras||{}), animationBindings:{ skeletonNodeId:skeleton.value, clips:[clip.value] }, stateMachine:parsed };
+  OutlinerService.setExtras(id.value, extras);
+}
+bus.on('animation:clips', c=>{ clips.value=c; });
+bus.on('selection:change', sel=> load(sel[0]));
+
+// Bloc 4 exports
+export default { name:'AnimationPanel', setup(){ return { id, clip, skeleton, blend, clips, sm, armatures, play, saveSM }; } };
+</script>

--- a/IdeWebGlGameEngine/src/components/inspector/PhysicsPanel.vue
+++ b/IdeWebGlGameEngine/src/components/inspector/PhysicsPanel.vue
@@ -1,0 +1,74 @@
+<template>
+  <div v-if="id">
+    <h3>Physics</h3>
+    <fieldset>
+      <legend>Collider</legend>
+      <select v-model="collider.type" @change="apply">
+        <option>box</option><option>sphere</option><option>capsule</option><option>mesh</option>
+      </select>
+      <div v-if="collider.type==='box'">
+        <input type="number" step="0.001" v-model.number="collider.size[0]" @change="apply" />
+        <input type="number" step="0.001" v-model.number="collider.size[1]" @change="apply" />
+        <input type="number" step="0.001" v-model.number="collider.size[2]" @change="apply" />
+      </div>
+      <div v-else-if="collider.type==='sphere'">
+        <input type="number" step="0.001" v-model.number="collider.radius" @change="apply" />
+      </div>
+      <div v-else-if="collider.type==='capsule'">
+        <input type="number" step="0.001" v-model.number="collider.radius" @change="apply" />
+        <input type="number" step="0.001" v-model.number="collider.height" @change="apply" />
+      </div>
+      <div>
+        <label>Offset</label>
+        <input type="number" step="0.001" v-model.number="collider.offset[0]" @change="apply" />
+        <input type="number" step="0.001" v-model.number="collider.offset[1]" @change="apply" />
+        <input type="number" step="0.001" v-model.number="collider.offset[2]" @change="apply" />
+      </div>
+      <label><input type="checkbox" v-model="collider.isTrigger" @change="apply" />Trigger</label>
+    </fieldset>
+    <fieldset>
+      <legend>Body</legend>
+      <select v-model="body.mode" @change="apply">
+        <option>Static</option><option>Dynamic</option><option>Kinematic</option>
+      </select>
+      <input type="number" step="0.001" v-model.number="body.mass" @change="apply" placeholder="Mass" />
+      <input type="number" step="0.001" v-model.number="body.friction" @change="apply" placeholder="Friction" />
+      <input type="number" step="0.001" v-model.number="body.restitution" @change="apply" placeholder="Restitution" />
+      <label><input type="checkbox" v-model="body.ccd" @change="apply" />CCD</label>
+      <input type="number" step="0.001" v-model.number="body.gravityScale" @change="apply" placeholder="Gravity" />
+    </fieldset>
+  </div>
+  <div v-else>Physics: no selection</div>
+</template>
+
+<script>
+// Bloc 1 imports
+import { reactive, ref } from 'vue';
+import bus from '../../js/core/bus.js';
+import { OutlinerService } from '../../js/services/outliner.service.js';
+
+// Bloc 2 state / types / constantes
+const id = ref(null);
+const collider = reactive({ type:'box', size:[1,1,1], radius:0.5, height:1, offset:[0,0,0], isTrigger:false });
+const body = reactive({ mode:'Static', mass:1, friction:0.5, restitution:0, ccd:false, gravityScale:1 });
+
+// Bloc 3 opérateurs
+function load(target){
+  id.value = target;
+  if(!target) return;
+  const obj = OutlinerService.snapshot().objects[target];
+  Object.assign(collider, { type:'box', size:[1,1,1], radius:0.5, height:1, offset:[0,0,0], isTrigger:false }, obj?.extras?.collider || {});
+  Object.assign(body, { mode:'Static', mass:1, friction:0.5, restitution:0, ccd:false, gravityScale:1 }, obj?.extras?.body || {});
+}
+function apply(){
+  if(!id.value) return;
+  const obj = OutlinerService.snapshot().objects[id.value];
+  const extras = { ...(obj.extras||{}), collider: { ...collider }, body: { ...body } };
+  OutlinerService.setExtras(id.value, extras);
+  bus.emit('physics:changed', { id:id.value, collider:{...collider}, body:{...body} });
+}
+bus.on('selection:change', sel => load(sel[0]));
+
+// Bloc 4 exports
+export default { name:'PhysicsPanel', setup(){ return { id, collider, body, apply }; } };
+</script>

--- a/IdeWebGlGameEngine/src/components/inspector/TransformInspector.vue
+++ b/IdeWebGlGameEngine/src/components/inspector/TransformInspector.vue
@@ -1,0 +1,68 @@
+<template>
+  <div v-if="currentId">
+    <h3>Transform</h3>
+    <div>Location (m)</div>
+    <div>
+      <input type="number" step="0.001" v-model.number="t.loc[0]" @keydown="onKey" @change="apply" />
+      <input type="number" step="0.001" v-model.number="t.loc[1]" @keydown="onKey" @change="apply" />
+      <input type="number" step="0.001" v-model.number="t.loc[2]" @keydown="onKey" @change="apply" />
+    </div>
+    <div>Rotation (°)</div>
+    <div>
+      <input type="number" step="0.001" v-model.number="t.rot[0]" @keydown="onKey" @change="apply" />
+      <input type="number" step="0.001" v-model.number="t.rot[1]" @keydown="onKey" @change="apply" />
+      <input type="number" step="0.001" v-model.number="t.rot[2]" @keydown="onKey" @change="apply" />
+      <select v-model="t.order" @change="apply">
+        <option>XYZ</option><option>XZY</option><option>YXZ</option><option>YZX</option><option>ZXY</option><option>ZYX</option>
+      </select>
+    </div>
+    <div>Scale</div>
+    <div>
+      <input type="number" step="0.001" v-model.number="t.scl[0]" @keydown="onKey" @change="apply" />
+      <input type="number" step="0.001" v-model.number="t.scl[1]" @keydown="onKey" @change="apply" />
+      <input type="number" step="0.001" v-model.number="t.scl[2]" @keydown="onKey" @change="apply" />
+    </div>
+    <div>
+      <label>Space</label>
+      <select v-model="t.space" @change="apply">
+        <option>Local</option>
+        <option>World</option>
+      </select>
+    </div>
+    <div>Dimensions (m)
+      <span>{{ t.dims[0].toFixed(3) }} {{ t.dims[1].toFixed(3) }} {{ t.dims[2].toFixed(3) }}</span>
+    </div>
+  </div>
+  <div v-else>No selection</div>
+</template>
+
+<script>
+// Bloc 1 imports
+import { reactive, ref } from 'vue';
+import bus from '../../js/core/bus.js';
+import Transform from '../../js/services/transform.controller.js';
+
+// Bloc 2 state / types / constantes
+const t = reactive({ loc:[0,0,0], rot:[0,0,0], scl:[1,1,1], order:'XYZ', space:'Local', dims:[1,1,1] });
+const currentId = ref(null);
+
+// Bloc 3 opérateurs
+function load(id){
+  currentId.value = id;
+  if(!id){ return; }
+  Object.assign(t, Transform.get(id));
+}
+function apply(){
+  if(!currentId.value) return;
+  Transform.set(currentId.value, { loc:[...t.loc], rot:[...t.rot], scl:[...t.scl], order:t.order, space:t.space, dims:[...t.dims] });
+}
+function onKey(e){
+  if(e.key==='Enter') apply();
+  if(e.key==='Escape') load(currentId.value);
+}
+bus.on('selection:change', sel => load(sel[0]));
+bus.on('transform:changed', ({id,t:tr})=>{ if(id===currentId.value) Object.assign(t,tr); });
+
+// Bloc 4 exports
+export default { name:'TransformInspector', setup(){ return { t, currentId, apply, onKey }; } };
+</script>

--- a/IdeWebGlGameEngine/src/js/services/animation.service.js
+++ b/IdeWebGlGameEngine/src/js/services/animation.service.js
@@ -1,0 +1,27 @@
+// Bloc 1 imports
+import bus from '../core/bus.js';
+
+// Bloc 2 state / types / constantes
+const _clips = [];
+const _bindings = new Map();
+
+// Bloc 3 opérateurs
+function loadClipsFromGLTF(json){
+  _clips.length = 0;
+  (json.animations||[]).forEach((a,i)=>{
+    _clips.push({ name: a.name||`Clip${i}`, duration: a.duration||0, raw:a });
+  });
+  bus.emit('animation:clips', getClips());
+}
+function getClips(){ return _clips.map(c=>({ ...c })); }
+function bindSkeleton(skeletonNodeId, clipName){
+  _bindings.set(skeletonNodeId, clipName);
+  bus.emit('animation:bind', { skeletonNodeId, clipName });
+}
+function play(skeletonNodeId, clipName, blendSeconds=0.2){
+  bus.emit('animation:play', { skeletonNodeId, clipName, blendSeconds });
+  // TODO mixer implementation
+}
+
+// Bloc 4 exports
+export default { loadClipsFromGLTF, bindSkeleton, play, getClips };

--- a/IdeWebGlGameEngine/src/js/services/gltf.importer.js
+++ b/IdeWebGlGameEngine/src/js/services/gltf.importer.js
@@ -1,0 +1,42 @@
+// Bloc 1 imports
+import bus from '../core/bus.js';
+import { OutlinerService } from './outliner.service.js';
+import AnimationService from './animation.service.js';
+
+// Bloc 2 state / types / constantes
+const TYPE = { MESH:'MESH', ARMATURE:'ARMATURE', CAMERA:'CAMERA', LIGHT:'LIGHT', EMPTY:'EMPTY' };
+
+// Bloc 3 opérateurs
+function importGLTF(json){
+  if(!json) return;
+  const nodeMap = new Map();
+  (json.scenes||[]).forEach((scene,si)=>{
+    const colId = OutlinerService.createCollection(OutlinerService.rootId(), scene.name||`Scene${si}`);
+    (scene.nodes||[]).forEach(nid=> traverseNode(nid,null,colId,json,nodeMap));
+  });
+  AnimationService.loadClipsFromGLTF(json);
+  bus.emit('outliner:loaded', OutlinerService.snapshot());
+}
+function traverseNode(idx,parentId,collectionId,json,nodeMap){
+  const node = json.nodes[idx];
+  const type = node.mesh!==undefined?TYPE.MESH:
+               node.skin!==undefined?TYPE.ARMATURE:
+               node.camera!==undefined?TYPE.CAMERA:
+               node.light!==undefined?TYPE.LIGHT:TYPE.EMPTY;
+  const obj = {
+    id: node.name||`Node${idx}`,
+    name: node.name||`Node${idx}`,
+    type,
+    parentId,
+    collectionId,
+    visible:true,
+    locked:false,
+    extras: node.extras||{}
+  };
+  const oid = OutlinerService.addObject(obj,parentId,collectionId);
+  nodeMap.set(idx,oid);
+  (node.children||[]).forEach(cid=> traverseNode(cid,oid,collectionId,json,nodeMap));
+}
+
+// Bloc 4 exports
+export default { importGLTF };

--- a/IdeWebGlGameEngine/src/js/services/outliner.service.js
+++ b/IdeWebGlGameEngine/src/js/services/outliner.service.js
@@ -1,78 +1,85 @@
-/* ===== STATE ===== */
+// Bloc 1 imports
+// none
+
+// Bloc 2 state / types / constantes
 const _state = {
   collections: new Map(),
   objects: new Map(),
   rootId: 'root',
-  selec: new Set(),
+  selection: new Set(),
   listeners: new Set(),
   nextId: 1,
 };
-function emit(evt, payload){ _state.listeners.forEach(fn => fn(evt, payload)); }
+function emit(evt,p){ _state.listeners.forEach(fn=>fn(evt,p)); }
 function ensureRoot(){
-  if (!_state.collections.has(_state.rootId)){
-    _state.collections.set(_state.rootId, { id:_state.rootId, name:'Scene', parentId:null, children:new Set(), objects:new Set() });
+  if(!_state.collections.has(_state.rootId)){
+    _state.collections.set(_state.rootId,{ id:_state.rootId, name:'Root', parentId:null, children:new Set(), objects:new Set() });
   }
 }
 ensureRoot();
 
-/* ===== API ===== */
-export const OutlinerService = {
-  on(fn){ _state.listeners.add(fn); return () => _state.listeners.delete(fn); },
-  createCollection(name='Collection', parentId=_state.rootId){
-    ensureRoot();
-    const id = 'C' + (_state.nextId++);
-    _state.collections.set(id, { id, name, parentId, children:new Set(), objects:new Set() });
-    _state.collections.get(parentId)?.children.add(id);
-    emit('collection:add', { id, parentId, name });
-    return id;
-  },
-  renameCollection(id, name){ const c = _state.collections.get(id); if(!c) return; c.name=name; emit('collection:rename', {id,name}); },
-  removeCollection(id){
-    if (id===_state.rootId) return;
-    const c=_state.collections.get(id); if(!c) return;
-    c.children.forEach(cid => { _state.collections.get(cid).parentId=c.parentId; _state.collections.get(c.parentId)?.children.add(cid); });
-    c.objects.forEach(oid => { const o=_state.objects.get(oid); if(o){ o.collectionId=c.parentId; _state.collections.get(c.parentId)?.objects.add(oid);} });
-    _state.collections.get(c.parentId)?.children.delete(id);
-    _state.collections.delete(id);
-    emit('collection:remove', {id});
-  },
-  moveCollection(id, newParentId){
-    const c=_state.collections.get(id); if(!c || id===_state.rootId) return;
-    _state.collections.get(c.parentId)?.children.delete(id);
-    c.parentId=newParentId;
-    _state.collections.get(newParentId)?.children.add(id);
-    emit('collection:move', {id,newParentId});
-  },
-  createObject(name='Object', type='Empty', collectionId=_state.rootId){
-    const id = 'O' + (_state.nextId++);
-    _state.objects.set(id, { id, name, type, collectionId });
-    _state.collections.get(collectionId)?.objects.add(id);
-    emit('object:add', { id, name, type, collectionId });
-    return id;
-  },
-  renameObject(id, name){ const o=_state.objects.get(id); if(!o) return; o.name=name; emit('object:rename', {id,name}); },
-  moveObject(id, targetCollectionId){
-    const o=_state.objects.get(id); if(!o) return;
-    _state.collections.get(o.collectionId)?.objects.delete(id);
-    o.collectionId=targetCollectionId;
-    _state.collections.get(targetCollectionId)?.objects.add(id);
-    emit('object:move', {id, targetCollectionId});
-  },
-  removeObject(id){
-    const o=_state.objects.get(id); if(!o) return;
-    _state.collections.get(o.collectionId)?.objects.delete(id);
-    _state.objects.delete(id);
-    _state.selec.delete(id);
-    emit('object:remove', {id});
-  },
-  clearSelection(){ _state.selec.clear(); emit('selection', new Set(_state.selec)); },
-  selectOnly(id){ _state.selec.clear(); if(id) _state.selec.add(id); emit('selection', new Set(_state.selec)); },
-  toggleSelect(id){ _state.selec.has(id)?_state.selec.delete(id):_state.selec.add(id); emit('selection', new Set(_state.selec)); },
-  getSelection(){ return Array.from(_state.selec); },
-  snapshot(){
-    const c = {}; _state.collections.forEach((v,k)=> c[k]={...v, children:Array.from(v.children), objects:Array.from(v.objects)});
-    const o = {}; _state.objects.forEach((v,k)=> o[k]={...v});
-    return { collections:c, objects:o, rootId:_state.rootId };
-  },
-};
+// Bloc 3 opérateurs
+function on(fn){ _state.listeners.add(fn); return ()=>_state.listeners.delete(fn); }
+function rootId(){ return _state.rootId; }
+function createCollection(parentId=_state.rootId,name='Collection',forceId){
+  ensureRoot();
+  const id = forceId || 'C'+(_state.nextId++);
+  _state.collections.set(id,{ id,name,parentId,children:new Set(),objects:new Set() });
+  _state.collections.get(parentId)?.children.add(id);
+  emit('collection:add',{id,parentId,name});
+  return id;
+}
+function renameCollection(id,name){ const c=_state.collections.get(id); if(!c) return; c.name=name; emit('collection:rename',{id,name}); }
+function removeCollection(id){
+  if(id===_state.rootId) return false;
+  const c=_state.collections.get(id); if(!c) return false;
+  if(c.children.size||c.objects.size) return false; // refuse if non empty
+  _state.collections.get(c.parentId)?.children.delete(id);
+  _state.collections.delete(id);
+  emit('collection:remove',{id});
+  return true;
+}
+function childrenOfCollection(id){ const c=_state.collections.get(id); if(!c) return {collections:[],objects:[]}; return { collections:[...c.children], objects:[...c.objects] }; }
+function addObject(obj,parentId=null,collectionId=_state.rootId){
+  const id = obj.id || 'O'+(_state.nextId++);
+  const o = { id, name:obj.name||id, type:obj.type||'EMPTY', parentId, collectionId, children:new Set(), visible:obj.visible!==false, locked:obj.locked||false, extras:obj.extras||{} };
+  _state.objects.set(id,o);
+  if(parentId) _state.objects.get(parentId)?.children.add(id);
+  _state.collections.get(collectionId)?.objects.add(id);
+  emit('object:add',{...o});
+  return id;
+}
+function renameObject(id,name){ const o=_state.objects.get(id); if(!o) return; o.name=name; emit('object:rename',{id,name}); }
+function removeObject(id){
+  const o=_state.objects.get(id); if(!o) return;
+  [...o.children].forEach(cid=>removeObject(cid));
+  _state.objects.get(o.parentId)?.children.delete(id);
+  _state.collections.get(o.collectionId)?.objects.delete(id);
+  _state.objects.delete(id);
+  _state.selection.delete(id);
+  emit('object:remove',{id});
+}
+function reparent(objectId,newParentId){
+  const o=_state.objects.get(objectId); if(!o || objectId===newParentId) return;
+  let cur=newParentId; while(cur){ if(cur===objectId) return; cur=_state.objects.get(cur)?.parentId; }
+  _state.objects.get(o.parentId)?.children.delete(objectId);
+  o.parentId=newParentId; _state.objects.get(newParentId)?.children.add(objectId);
+  emit('object:reparent',{id:objectId,parentId:newParentId});
+}
+function moveToCollection(objectId,collectionId){ const o=_state.objects.get(objectId); if(!o) return; _state.collections.get(o.collectionId)?.objects.delete(objectId); o.collectionId=collectionId; _state.collections.get(collectionId)?.objects.add(objectId); emit('object:move',{id:objectId,collectionId}); }
+function toggleVisible(id){ const o=_state.objects.get(id); if(!o) return; o.visible=!o.visible; emit('object:visible',{id,visible:o.visible}); }
+function toggleLocked(id){ const o=_state.objects.get(id); if(!o) return; o.locked=!o.locked; emit('object:locked',{id,locked:o.locked}); }
+function clearSelection(){ _state.selection.clear(); emit('selection', getSelection()); }
+function selectOnly(id){ _state.selection.clear(); if(id) _state.selection.add(id); emit('selection', getSelection()); }
+function toggleSelect(id){ _state.selection.has(id)?_state.selection.delete(id):_state.selection.add(id); emit('selection', getSelection()); }
+function getSelection(){ return [..._state.selection]; }
+function setExtras(id,extras){ const o=_state.objects.get(id); if(o) o.extras=extras; }
+function snapshot(){
+  const c={}; _state.collections.forEach((v,k)=> c[k]={ id:v.id,name:v.name,parentId:v.parentId,children:[...v.children],objects:[...v.objects] });
+  const o={}; _state.objects.forEach((v,k)=>{ o[k]={ id:v.id,name:v.name,type:v.type,parentId:v.parentId,collectionId:v.collectionId,children:[...v.children],visible:v.visible,locked:v.locked,extras:v.extras }; });
+  return { collections:c, objects:o, rootId:_state.rootId };
+}
+
+// Bloc 4 exports
+export const OutlinerService = { on, rootId, createCollection, renameCollection, removeCollection, childrenOfCollection, addObject, renameObject, removeObject, reparent, moveToCollection, toggleVisible, toggleLocked, clearSelection, selectOnly, toggleSelect, getSelection, setExtras, snapshot };
 export default OutlinerService;

--- a/IdeWebGlGameEngine/src/js/services/transform.controller.js
+++ b/IdeWebGlGameEngine/src/js/services/transform.controller.js
@@ -1,0 +1,21 @@
+// Bloc 1 imports
+import bus from '../core/bus.js';
+
+// Bloc 2 state / types / constantes
+const _t = new Map();
+const _def = { loc:[0,0,0], rot:[0,0,0], scl:[1,1,1], space:'Local', order:'XYZ', dims:[1,1,1] };
+
+// Bloc 3 opérateurs
+function get(id){
+  return _t.get(id) || { ..._def };
+}
+function set(id, tr){
+  const cur = { ..._def, ...(tr||{}) };
+  _t.set(id, cur);
+  // TODO: apply to runtime (world/local conversions)
+  bus.emit('transform:changed', { id, t: { ...cur } });
+  return cur;
+}
+
+// Bloc 4 exports
+export default { get, set };


### PR DESCRIPTION
## Summary
- add glTF importer converting scenes and nodes to collections and objects
- extend outliner service and UI with hierarchy, drag & drop, visibility, lock and selection
- integrate transform, physics, animation and game properties panels into inspector

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68a1012bf8a0832e9e5c311f83adbe33