### PR TITLE
feat: enhance dom outliner

### DIFF
--- a/IdeWebGlGameEngine/index.html
+++ b/IdeWebGlGameEngine/index.html
@@ -36,6 +36,8 @@
     }
   </script>
 
+  <link rel="stylesheet" href="/styles/overrides.css">
+
   <style>
     /* --- Layout / UX --- */
     .divider-v{ width:6px; cursor:col-resize }
@@ -124,7 +126,25 @@
       <aside id="left-pane" class="w-64 min-w-48 max-w-[40vw] bg-panel/60 border-r border-white/5 flex flex-col">
         <div class="px-3 py-2 border-b border-white/5"><h2 class="text-xs uppercase tracking-wider text-slate-400">Outliner</h2></div>
         <div class="grow min-h-0 overflow-auto p-2 space-y-3">
-          <div data-role="outliner-list" class="outliner-list"></div>
+          <div data-role="outliner-list" class="outliner-list"
+               data-tree-class="outliner__tree"
+               data-node-class="outliner__node"
+               data-twisty-class="outliner__twisty"
+               data-vis-class="outliner__vis"
+               data-name-class="outliner__name"
+               data-actions-class="outliner__actions"
+               data-toolbar-class="outliner__toolbar"
+               data-btn-class="outliner__btn"
+               data-selected-class="outliner--selected">
+            <div class="outliner__toolbar" data-role="outliner-toolbar">
+              <button class="outliner__btn" data-act="new">+ New Collection</button>
+              <button class="outliner__btn" data-act="expand">Expand All</button>
+              <button class="outliner__btn" data-act="collapse">Collapse All</button>
+              <input class="outliner__btn" data-role="search" type="search" placeholder="Search" />
+              <button class="outliner__btn" data-act="unparent">Unparent</button>
+              <button class="outliner__btn" data-act="delete">Delete</button>
+            </div>
+          </div>
         </div>
       </aside>
       <div id="div-left" class="divider-v bg-white/5"></div>

--- a/IdeWebGlGameEngine/public/styles/overrides.css
+++ b/IdeWebGlGameEngine/public/styles/overrides.css
@@ -2,3 +2,14 @@
 #node-area, [data-role="vs-area"] { position: relative; overflow: hidden; pointer-events: auto; }
 #node-area .overlay, #node-area svg, #node-area canvas.decor { pointer-events: none; } /* les overlays ne bloquent pas le drop */
 #node-area .node { position: absolute; z-index: 10; pointer-events: auto; }
+
+/* Outliner */
+.outliner__toolbar{display:flex;gap:4px;margin-bottom:4px;}
+.outliner__btn{padding:2px 4px;font-size:12px;background:var(--outliner-btn-bg,transparent);border:1px solid rgba(255,255,255,0.1);border-radius:2px;}
+.outliner__tree{list-style:none;margin:0;padding-left:0;}
+.outliner__node{user-select:none;}
+.outliner__node>div{display:flex;align-items:center;gap:4px;padding:2px 4px;}
+.outliner__twisty{cursor:pointer;width:1em;display:inline-block;}
+.outliner__name{flex:1;}
+.outliner__actions button{margin-left:4px;}
+.outliner--selected>div{background-color:rgba(56,189,248,.2);}

--- a/IdeWebGlGameEngine/src/js/app.js
+++ b/IdeWebGlGameEngine/src/js/app.js
@@ -6,7 +6,6 @@
 import { renderLibrary } from './modules/visual/Library.js';
 import Inspector from './modules/ui/inspector/inspector.js';
 import View3D from './modules/viewport3d/engine.js';              // optionnel : fonctionne même sans canvas
-import Outliner from './modules/ui/outliner.js';
 import { attachContextMenu } from './modules/visual/context.js';   // optionnel : ok si absent
 import { setContext } from './modules/context.js';
 
@@ -71,14 +70,7 @@ function initInspectorUI(active = 'visual_scripting') {
   setContext(active);
 }
 
-// BLOCK 6 — initOutliner (version simple liée au contexte)
-function initOutlinerUI() {
-  const panel = $('[data-role="outliner-list"]');
-  if (!panel) return;
-  try { Outliner.initOutliner(panel); } catch (_) {}
-}
-
-// BLOCK 7 — initNodeAreaDnD (Library -> Visual Scripting)
+// BLOCK 6 — initNodeAreaDnD (Library -> Visual Scripting)
 function initNodeAreaDnD() {
   const area = $('#node-area') || $('[data-role="vs-area"]');
   if (!area) return;
@@ -114,14 +106,14 @@ function initNodeAreaDnD() {
   });
 }
 
-// BLOCK 8 — initContextMenu (right click)
+// BLOCK 7 — initContextMenu (right click)
 function initContextMenu() {
   const area = $('#node-area') || $('[data-role="vs-area"]');
   if (!area || !window.graph) return;
   try { attachContextMenu(area, window.graph); } catch (_) {}
 }
 
-// BLOCK 9 — initTabs (IDE tabs)
+// BLOCK 8 — initTabs (IDE tabs)
 function initTabs() {
   const sections = $$('.ide-tab')
     .map((btn) => {
@@ -163,12 +155,11 @@ function initTabs() {
   if (first) first.classList.add('bg-white/10');
 }
 
-// BLOCK 10 — initUI + DOM ready
+// BLOCK 9 — initUI + DOM ready
 async function initUI() {
   await ensureGraph();
   await initLibrary();
   initInspectorUI('visual_scripting');
-  initOutlinerUI();
   initNodeAreaDnD();
   initContextMenu();
   initTabs();

--- a/IdeWebGlGameEngine/src/js/services/gltf.importer.js
+++ b/IdeWebGlGameEngine/src/js/services/gltf.importer.js
@@ -5,22 +5,27 @@ import { OutlinerService } from './outliner.service.js';
 const { TYPE } = OutlinerService;
 
 // Bloc 3 opérateurs
-function nodeType(node){
-  return node.mesh!==undefined?TYPE.MESH:
-         node.skin!==undefined?TYPE.ARMATURE:
-         node.camera!==undefined?TYPE.CAMERA:
-         node.light!==undefined?TYPE.LIGHT:TYPE.EMPTY;
-}
 export async function importGLTF(url){
   const res = await fetch(url);
   const json = await res.json();
   const name = url.split('/').pop().replace(/\.gltf$/i,'').replace(/\.glb$/i,'');
   const importId = Date.now().toString(36);
   const colId = OutlinerService.registerCollection(importId, name);
+  const jointNodes = new Set();
+  (json.skins||[]).forEach(s=> (s.joints||[]).forEach(j=> jointNodes.add(j)));
+  function nodeType(idx){
+    const node = json.nodes[idx];
+    if(jointNodes.has(idx)) return TYPE.BONE;
+    if(node.mesh!==undefined) return TYPE.MESH;
+    if(node.skin!==undefined) return TYPE.ARMATURE;
+    if(node.camera!==undefined) return TYPE.CAMERA;
+    if(node.light!==undefined) return TYPE.LIGHT;
+    return TYPE.EMPTY;
+  }
   const traverse = (idx,parentId)=>{
     const n = json.nodes[idx];
     const id = n.name || `node${idx}`;
-    OutlinerService.addNode({ id, name:n.name||id, type:nodeType(n), parentId });
+    OutlinerService.addNode({ id, name:n.name||id, type:nodeType(idx), parentId });
     (n.children||[]).forEach(c=> traverse(c,id));
   };
   (json.scenes?.[0]?.nodes||[]).forEach(n=> traverse(n,colId));

--- a/IdeWebGlGameEngine/src/js/services/outliner.service.js
+++ b/IdeWebGlGameEngine/src/js/services/outliner.service.js
@@ -2,7 +2,7 @@
 import bus from '../core/bus.js';
 
 // Bloc 2 constantes/dictionnaires
-const TYPE = { COLLECTION:'COLLECTION', MESH:'MESH', ARMATURE:'ARMATURE', CAMERA:'CAMERA', LIGHT:'LIGHT', EMPTY:'EMPTY' };
+const TYPE = { COLLECTION:'COLLECTION', MESH:'MESH', ARMATURE:'ARMATURE', BONE:'BONE', CAMERA:'CAMERA', LIGHT:'LIGHT', EMPTY:'EMPTY', GROUP:'GROUP' };
 const _state = {
   nodes: new Map(),
   expanded: new Map(),
@@ -68,6 +68,17 @@ function reparent(id,newParentId){
 }
 function setExpanded(id,bool){ _state.expanded.set(id,!!bool); }
 function getExpanded(id){ return _state.expanded.get(id)||false; }
+function removeNode(id){
+  if(id==='root') return;
+  const node=_state.nodes.get(id); if(!node) return;
+  if(isLocked(id)) return;
+  [...node.children].forEach(c=>removeNode(c));
+  const parent=_state.nodes.get(node.parentId);
+  if(parent) parent.children=parent.children.filter(cid=>cid!==id);
+  _state.nodes.delete(id);
+  if(_state.selection===id) _state.selection=null;
+  notify();
+}
 
 // Bloc 4 exports
 export const OutlinerService = {
@@ -86,6 +97,7 @@ export const OutlinerService = {
   reparent,
   setExpanded,
   getExpanded,
+  removeNode,
   onChange,
 };
 export default OutlinerService;

--- a/IdeWebGlGameEngine/src/js/ui/outliner.dom.js
+++ b/IdeWebGlGameEngine/src/js/ui/outliner.dom.js
@@ -2,66 +2,115 @@
 import { OutlinerService } from '../services/outliner.service.js';
 
 // Bloc 2 constantes/dictionnaires
-const ICONS = { COLLECTION:'🗂️', MESH:'🧊', ARMATURE:'🦴', CAMERA:'📷', LIGHT:'💡', EMPTY:'◻️' };
+const ICONS = { COLLECTION:'🗂️', MESH:'🧊', ARMATURE:'🦴', BONE:'🦴', CAMERA:'📷', LIGHT:'💡', EMPTY:'◻️', GROUP:'◻️' };
 
 // Bloc 3 opérateurs
 export function mountOutliner(root){
   if(!root) return;
   const CLS = {
-    tree: root.dataset.treeClass || 'tree',
-    node: root.dataset.nodeClass || 'node',
-    twisty: root.dataset.twistyClass || 'twisty',
-    vis: root.dataset.visClass || 'vis',
-    name: root.dataset.nameClass || 'name',
-    actions: root.dataset.actionsClass || 'actions',
+    tree: root.dataset.treeClass || 'outliner__tree',
+    node: root.dataset.nodeClass || 'outliner__node',
+    twisty: root.dataset.twistyClass || 'outliner__twisty',
+    vis: root.dataset.visClass || 'outliner__vis',
+    name: root.dataset.nameClass || 'outliner__name',
+    actions: root.dataset.actionsClass || 'outliner__actions',
+    toolbar: root.dataset.toolbarClass || 'outliner__toolbar',
+    btn: root.dataset.btnClass || 'outliner__btn',
+    selected: root.dataset.selectedClass || 'outliner--selected',
   };
-  function render(){
-    root.innerHTML = '';
-    const ul = document.createElement('ul');
-    ul.className = CLS.tree;
-    root.appendChild(ul);
-    OutlinerService.getChildren('root').forEach(id=> buildNode(id, ul));
+  let filter = '';
+
+  // toolbar
+  const toolbar = root.querySelector('[data-role="outliner-toolbar"]') || (()=>{const t=document.createElement('div');t.dataset.role='outliner-toolbar';root.appendChild(t);return t;})();
+  toolbar.classList.add(CLS.toolbar);
+  if(!toolbar._init){
+    toolbar.innerHTML = `<button data-act="new" class="${CLS.btn}">+ New Collection</button>
+    <button data-act="expand" class="${CLS.btn}">Expand All</button>
+    <button data-act="collapse" class="${CLS.btn}">Collapse All</button>
+    <input data-role="search" class="${CLS.btn}" type="search" placeholder="Search"/>
+    <button data-act="unparent" class="${CLS.btn}">Unparent</button>
+    <button data-act="delete" class="${CLS.btn}">Delete</button>`;
+    const search = toolbar.querySelector('[data-role="search"]');
+    search.addEventListener('input', e=>{ filter = e.target.value.toLowerCase(); render(); });
+    toolbar.addEventListener('click', e=>{
+      const act = e.target.dataset.act;
+      if(!act) return;
+      e.preventDefault();
+      const sel = OutlinerService.getSelection();
+      if(act==='new'){ OutlinerService.registerCollection(Date.now().toString(36),'Collection'); }
+      else if(act==='expand'){ traverse('root', id=>OutlinerService.setExpanded(id,true)); render(); }
+      else if(act==='collapse'){ traverse('root', id=>OutlinerService.setExpanded(id,false)); render(); }
+      else if(act==='unparent' && sel){ OutlinerService.reparent(sel,'root'); }
+      else if(act==='delete' && sel){ OutlinerService.removeNode(sel); }
+    });
+    toolbar._init = true;
   }
+
+  const treeRoot = root.querySelector('ul') || root.appendChild(document.createElement('ul'));
+  treeRoot.className = CLS.tree;
+
+  function traverse(id,fn){ fn(id); OutlinerService.getChildren(id).forEach(cid=>traverse(cid,fn)); }
+  function matches(id){ if(!filter) return true; const name=OutlinerService.getName(id).toLowerCase(); if(name.includes(filter)) return true; return OutlinerService.getChildren(id).some(matches); }
+
+  function render(){
+    treeRoot.innerHTML = '';
+    OutlinerService.getChildren('root').forEach(id=> buildNode(id, treeRoot));
+  }
+
   function buildNode(id, parent){
+    const kids = OutlinerService.getChildren(id);
+    const matchSelf = OutlinerService.getName(id).toLowerCase().includes(filter);
+    const childMatches = kids.filter(matches);
+    if(filter && !matchSelf && childMatches.length===0) return;
+
     const li = document.createElement('li');
     li.className = CLS.node;
     li.dataset.id = id;
     li.draggable = !OutlinerService.isLocked(id);
+
     const row = document.createElement('div');
-    const kids = OutlinerService.getChildren(id);
     const twisty = document.createElement('span');
     twisty.className = CLS.twisty;
-    twisty.textContent = kids.length ? (OutlinerService.getExpanded(id)?'▾':'▸') : '';
-    twisty.onclick = e=>{ e.stopPropagation(); if(kids.length){ OutlinerService.setExpanded(id,!OutlinerService.getExpanded(id)); render(); } };
+    const expanded = filter ? true : OutlinerService.getExpanded(id);
+    twisty.textContent = kids.length ? (expanded?'▾':'▸') : '';
+    twisty.onclick = e=>{ e.stopPropagation(); if(kids.length){ OutlinerService.setExpanded(id,!expanded); render(); } };
+
     const icon = document.createElement('span');
     icon.textContent = ICONS[OutlinerService.getType(id)] || '';
     const name = document.createElement('span');
     name.className = CLS.name;
     name.textContent = OutlinerService.getName(id);
+
     const eye = document.createElement('button');
     eye.className = CLS.vis;
     eye.textContent = OutlinerService.isVisible(id) ? '👁️' : '🙈';
     eye.onclick = e=>{ e.stopPropagation(); OutlinerService.toggleVisibility(id); };
+
     const lock = document.createElement('button');
     lock.textContent = OutlinerService.isLocked(id) ? '🔒' : '🔓';
     lock.onclick = e=>{ e.stopPropagation(); OutlinerService.toggleLock(id); };
+
     const acts = document.createElement('span');
     acts.className = CLS.actions;
     acts.append(eye, lock);
     row.append(twisty, icon, name, acts);
     row.onclick = ()=>{ if(OutlinerService.isLocked(id)) return; OutlinerService.selectOnly(id); };
     li.appendChild(row);
-    if(OutlinerService.getSelection()===id) li.classList.add('selected');
-    if(kids.length && OutlinerService.getExpanded(id)){
+    if(OutlinerService.getSelection()===id) li.classList.add(CLS.selected);
+
+    const showKids = expanded && (filter ? childMatches.length : kids.length);
+    if(showKids){
       const ul = document.createElement('ul');
-      kids.forEach(cid=> buildNode(cid, ul));
+      (filter ? childMatches : kids).forEach(cid=> buildNode(cid, ul));
       li.appendChild(ul);
     }
+
     li.addEventListener('dragstart', e=>{ e.dataTransfer.setData('text/plain', id); });
     li.addEventListener('dragover', e=>{ if(!OutlinerService.isLocked(id)) e.preventDefault(); });
     li.addEventListener('drop', e=>{ e.preventDefault(); const src=e.dataTransfer.getData('text/plain'); if(src && src!==id){ if(OutlinerService.reparent(src,id)) render(); } });
     parent.appendChild(li);
   }
+
   render();
   OutlinerService.onChange(render);
 }

--- a/IdeWebGlGameEngine/src/main.dom.js
+++ b/IdeWebGlGameEngine/src/main.dom.js
@@ -10,7 +10,8 @@ const { importGLTF } = GLTFImporter;
 async function boot(){
   let outEl = document.querySelector('#outliner') ||
               document.querySelector('.outliner') ||
-              document.querySelector('[data-role="outliner"]');
+              document.querySelector('[data-role="outliner"]') ||
+              document.querySelector('[data-role="outliner-list"]');
   if(!outEl){
     outEl = document.createElement('div');
     outEl.id = 'outliner';


### PR DESCRIPTION
## Summary
- add DOM-based outliner toolbar, search, and hierarchy controls
- extend outliner service and GLTF importer for richer node types
- wire DOM bootstrap to existing containers and styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npm run preview` *(fails: spawn xdg-open ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c1286adc832e9dbe92cfa131d39c