### PR TITLE
Refactor inspector routing and game property inputs

### DIFF
--- a/IdeWebGlGameEngine/src/js/app.js
+++ b/IdeWebGlGameEngine/src/js/app.js
@@ -8,7 +8,6 @@ import { renderLibrary } from './modules/visual/Library.js';
 import Inspector from './modules/ui/inspector/inspector.js';
 import View3D from './modules/viewport3d/engine.js';              // optionnel : fonctionne même sans canvas
 import { attachContextMenu } from './modules/visual/context.js';   // optionnel : ok si absent
-import { setContext } from './modules/context.js';
 
 // BLOCK 2 — HELPERS
 const $  = (sel, root = document) => root.querySelector(sel);
@@ -64,11 +63,10 @@ async function initLibrary() {
 }
 
 // BLOCK 5 — initInspectorUI
-function initInspectorUI(active = 'visual_scripting') {
+function initInspectorUI() {
   const insp = $('[data-role="inspector"]');
   if (!insp) return;
-  Inspector.initInspector(insp);
-  setContext(active);
+  Inspector.mount(insp);
 }
 
 // BLOCK 6 — initNodeAreaDnD (Library -> Visual Scripting)
@@ -128,8 +126,8 @@ function initTabs() {
 
   function show(key) {
     sections.forEach(({ key: k, el }) => el.classList.toggle('hidden', k !== key));
-    const map = { visual: 'visual_scripting', code: 'code', viewport: 'viewport_3d' };
-    setContext(map[key] || 'visual_scripting');
+    const map = { visual: 'visual', code: 'code', viewport: 'viewport' };
+    EventBus.emit('context.changed', { ctx: map[key] || 'visual' });
 
     if (key === 'viewport') {
       const canvas = $('[data-role="viewport3d-canvas"]');
@@ -160,10 +158,11 @@ function initTabs() {
 async function initUI() {
   await ensureGraph();
   await initLibrary();
-  initInspectorUI('visual_scripting');
+  initInspectorUI();
   initNodeAreaDnD();
   initContextMenu();
   initTabs();
+  EventBus.emit('context.changed', { ctx: 'viewport' });
   EventBus.on('context.changed', ctx => console.log('[app] context:', ctx));
 }
 

--- a/IdeWebGlGameEngine/src/js/modules/ui/inspector/inspector_code.js
+++ b/IdeWebGlGameEngine/src/js/modules/ui/inspector/inspector_code.js
@@ -1,44 +1,34 @@
 // PATH: src/js/modules/ui/inspector/inspector_code.js
 // Bloc 1 — imports
-import { EventBus } from '../../system/event_bus.js';
-import * as GameProps from '../../data/game_properties.js';
+import CodeGen from '../../../services/codegen.service.js';
 
-// Bloc 2 — dictionaries / constants
-let currentId = null;
-EventBus.on('selection.changed', data=>{ currentId = typeof data === 'object' ? data.id : data; });
+// Bloc 2 — dictionaries/constants
+// (none)
 
-// Bloc 3 — classes / functions / logic
-export function render(el){
-  const id = currentId;
-  if(!id){ el.textContent = 'Sélectionnez un objet dans l\'Outliner'; return; }
-  const titre = document.createElement('h4');
-  titre.textContent = 'Game Properties';
-  titre.className = 'mb-2 text-xs text-slate-400';
-  el.appendChild(titre);
-  renderGameProps(el, id);
-}
-function renderGameProps(el, id){
-  const list = document.createElement('div'); el.appendChild(list);
-  function refresh(){
-    list.innerHTML = '';
-    GameProps.list(id).forEach(gp=>{
-      const row = document.createElement('div'); row.className='flex items-center gap-1 py-1';
-      const name = document.createElement('input'); name.value=gp.name; name.className='w-24 bg-slate-700 text-xs px-1';
-      const type = document.createElement('select'); ['bool','int','float','string'].forEach(t=>{ const o=document.createElement('option'); o.value=t;o.textContent=t; if(gp.type===t)o.selected=true; type.appendChild(o); }); type.className='bg-slate-700 text-xs';
-      const val = document.createElement('input'); val.value=gp.value; val.className='flex-1 bg-slate-700 text-xs px-1';
-      const del = document.createElement('button'); del.textContent='×'; del.className='text-red-400 px-1';
-      del.onclick=()=>{ GameProps.remove(id, gp.name); refresh(); };
-      name.onchange=()=>{ GameProps.rename(id, gp.name, name.value); refresh(); };
-      type.onchange=()=>{ GameProps.set(id, gp.name, type.value, val.value); refresh(); };
-      val.onchange=()=>{ GameProps.set(id, gp.name, gp.type, val.value); refresh(); };
-      row.append(name,type,val,del); list.appendChild(row);
-    });
-  }
-  refresh();
-  const add = document.createElement('button'); add.textContent='Ajouter'; add.className='mt-2 px-2 py-1 bg-slate-700 text-xs';
-  add.onclick=()=>{ GameProps.set(id,'prop','bool',false); refresh(); };
-  el.appendChild(add);
+// Bloc 3 — classes/functions/logic
+export function mount(root){
+  root.innerHTML = '';
+  const wrap = document.createElement('div');
+  wrap.className = 'flex flex-col gap-2';
+  const gen = document.createElement('button');
+  gen.textContent = 'Generate JS';
+  gen.className = 'px-2 py-1 bg-slate-700 text-xs';
+  const sim = document.createElement('button');
+  sim.textContent = 'Simulate';
+  sim.className = 'px-2 py-1 bg-slate-700 text-xs';
+  const log = document.createElement('pre');
+  log.className = 'mt-2 bg-slate-900 text-xs p-2';
+  gen.onclick = () => {
+    const code = CodeGen.generate(null, 'Graph');
+    log.textContent = code;
+  };
+  sim.onclick = () => {
+    CodeGen.simulate(null);
+    log.textContent = 'Simulation logged in console';
+  };
+  wrap.append(gen, sim, log);
+  root.appendChild(wrap);
 }
 
-// Bloc 4 — event wiring / init
-export default { render };
+// Bloc 4 — event wiring/init
+export default { mount };

--- a/IdeWebGlGameEngine/src/js/modules/ui/inspector/inspector_visual.js
+++ b/IdeWebGlGameEngine/src/js/modules/ui/inspector/inspector_visual.js
@@ -2,49 +2,119 @@
 // Bloc 1 — imports
 import { EventBus } from '../../system/event_bus.js';
 import * as GameProps from '../../data/game_properties.js';
-import CodeGen from '../../../services/codegen.service.js';
 
-// Bloc 2 — dictionaries / constants
+// Bloc 2 — dictionaries/constants
 let currentId = null;
-EventBus.on('selection.changed', data=>{ currentId = typeof data === 'object' ? data.id : data; });
+let root = null;
+EventBus.on('selection.changed', data => {
+  currentId = typeof data === 'object' ? data.id : data;
+  if (root) render();
+});
 
-// Bloc 3 — classes / functions / logic
-export function render(el){
-  const id = currentId;
-  if(!id){ el.textContent='Sélectionnez un node pour voir ses propriétés'; return; }
-  renderGameProps(el, id);
-  renderActions(el, id);
+// Bloc 3 — classes/functions/logic
+export function mount(el){
+  root = el;
+  render();
 }
-function renderGameProps(el, id){
-  const list = document.createElement('div'); el.appendChild(list);
+
+function render(){
+  const id = currentId;
+  root.innerHTML = '';
+  if(!id){ root.textContent = 'Sélectionnez un node pour voir ses propriétés'; return; }
+  renderProperties(root, id);
+}
+
+function renderProperties(container, id){
+  const list = document.createElement('div');
+  container.appendChild(list);
   function refresh(){
     list.innerHTML = '';
-    GameProps.list(id).forEach(gp=>{
-      const row = document.createElement('div'); row.className='flex items-center gap-1 py-1';
-      const name = document.createElement('input'); name.value=gp.name; name.className='w-24 bg-slate-700 text-xs px-1';
-      const type = document.createElement('select'); ['bool','int','float','string'].forEach(t=>{ const o=document.createElement('option'); o.value=t;o.textContent=t; if(gp.type===t)o.selected=true; type.appendChild(o); }); type.className='bg-slate-700 text-xs';
-      const val = document.createElement('input'); val.value=gp.value; val.className='flex-1 bg-slate-700 text-xs px-1';
-      const del = document.createElement('button'); del.textContent='×'; del.className='text-red-400 px-1';
-      del.onclick=()=>{ GameProps.remove(id, gp.name); refresh(); };
-      name.onchange=()=>{ GameProps.rename(id, gp.name, name.value); refresh(); };
-      type.onchange=()=>{ GameProps.set(id, gp.name, type.value, val.value); refresh(); };
-      val.onchange=()=>{ GameProps.set(id, gp.name, gp.type, val.value); refresh(); };
-      row.append(name,type,val,del); list.appendChild(row);
+    GameProps.list(id).forEach(gp => {
+      const row = document.createElement('div');
+      row.className = 'flex items-center gap-1 py-1';
+      const name = document.createElement('input');
+      name.value = gp.name;
+      name.className = 'w-24 bg-slate-700 text-xs px-1';
+      const type = document.createElement('select');
+      ['bool','int','float','string'].forEach(t => {
+        const o = document.createElement('option');
+        o.value = t; o.textContent = t; if(gp.type===t) o.selected = true; type.appendChild(o);
+      });
+      type.className = 'bg-slate-700 text-xs';
+      const valWrap = document.createElement('span');
+      function valueInput(t, v){
+        let input;
+        switch(t){
+          case 'bool':
+            input = document.createElement('input');
+            input.type = 'checkbox';
+            input.checked = Boolean(v);
+            input.onchange = () => { GameProps.set(id, gp.name, t, castValue(t, input.checked)); refresh(); };
+            break;
+          case 'int':
+            input = document.createElement('input');
+            input.type = 'number';
+            input.step = '1';
+            input.value = parseInt(v)||0;
+            input.onchange = () => { GameProps.set(id, gp.name, t, castValue(t, input.value)); refresh(); };
+            break;
+          case 'float':
+            input = document.createElement('input');
+            input.type = 'number';
+            input.step = '0.01';
+            input.value = (parseFloat(v)||0).toFixed(2);
+            input.onchange = () => { GameProps.set(id, gp.name, t, castValue(t, input.value)); refresh(); };
+            break;
+          default:
+            input = document.createElement('input');
+            input.type = 'text';
+            input.value = v ?? '';
+            input.onchange = () => { GameProps.set(id, gp.name, t, castValue(t, input.value)); refresh(); };
+        }
+        input.className = 'flex-1 bg-slate-700 text-xs px-1';
+        return input;
+      }
+      let valInput = valueInput(gp.type, gp.value);
+      valWrap.appendChild(valInput);
+
+      const del = document.createElement('button');
+      del.textContent = '×';
+      del.className = 'text-red-400 px-1';
+      del.onclick = () => { GameProps.remove(id, gp.name); refresh(); };
+      name.onchange = () => { GameProps.rename(id, gp.name, name.value); refresh(); };
+      type.onchange = () => {
+        const newType = type.value;
+        GameProps.set(id, gp.name, newType, defaultValue(newType));
+        refresh();
+      };
+      row.append(name, type, valWrap, del);
+      list.appendChild(row);
     });
   }
   refresh();
-  const add = document.createElement('button'); add.textContent='Ajouter'; add.className='mt-2 px-2 py-1 bg-slate-700 text-xs';
-  add.onclick=()=>{ GameProps.set(id,'prop','bool',false); refresh(); };
-  el.appendChild(add);
-}
-function renderActions(el, id){
-  const wrap = document.createElement('div'); wrap.className='mt-4 flex gap-2';
-  const gen = document.createElement('button'); gen.textContent='Generate JS'; gen.className='px-2 py-1 bg-slate-700 text-xs';
-  gen.onclick=()=>{ CodeGen.generate({ id }, 'Node'+id); };
-  const sim = document.createElement('button'); sim.textContent='Simulate'; sim.className='px-2 py-1 bg-slate-700 text-xs';
-  sim.onclick=()=>{ CodeGen.simulate({ id }); };
-  wrap.append(gen, sim); el.appendChild(wrap);
+  const add = document.createElement('button');
+  add.textContent = 'Ajouter';
+  add.className = 'mt-2 px-2 py-1 bg-slate-700 text-xs';
+  add.onclick = () => { GameProps.set(id, 'prop', 'bool', false); refresh(); };
+  container.appendChild(add);
 }
 
-// Bloc 4 — event wiring / init
-export default { render };
+function defaultValue(t){
+  switch(t){
+    case 'bool': return false;
+    case 'int': return 0;
+    case 'float': return 0.0;
+    default: return '';
+  }
+}
+function castValue(t,v){
+  switch(t){
+    case 'bool': return !!v;
+    case 'int': return parseInt(v)||0;
+    case 'float': return parseFloat(v)||0;
+    default: return String(v||'');
+  }
+}
+
+// Bloc 4 — event wiring/init
+export default { mount };


### PR DESCRIPTION
## Summary
- refactor inspector to mount/unmount panels via context events
- rewire app to emit inspector context changes and default to viewport
- rework visual inspector inputs to follow property types and add code panel for generation/simulation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a32185fb20832e95145cba110fda7e